### PR TITLE
Expand data attributes

### DIFF
--- a/lib/teacup.js
+++ b/lib/teacup.js
@@ -105,8 +105,20 @@
     };
 
     Teacup.prototype.renderAttr = function(name, value) {
+      var k, v;
       if ((value == null) || value === false) {
         return '';
+      }
+      if (name === 'data' && typeof value === 'object') {
+        return ((function() {
+          var _results;
+          _results = [];
+          for (k in value) {
+            v = value[k];
+            _results.push(this.renderAttr("data-" + k, v));
+          }
+          return _results;
+        }).call(this)).join('');
       }
       if (value === true) {
         value = name;

--- a/src/teacup.coffee
+++ b/src/teacup.coffee
@@ -76,6 +76,9 @@ class Teacup
   renderAttr: (name, value) -> 
     if not value? or value is false
       return ''
+
+    if name is 'data' and typeof value is 'object'
+      return (@renderAttr "data-#{k}", v for k,v of value).join('')
     
     if value is true
       value = name

--- a/test/attributes.coffee
+++ b/test/attributes.coffee
@@ -37,3 +37,8 @@ describe 'Attributes', ->
     it 'is comma separated', ->
       template = -> br foo: [1, 2, 3]
       expect(render template).to.equal '<br foo="1,2,3" />'
+
+  describe 'data attribute', ->
+    it 'expands attributes', ->
+      template = -> br data: { name: 'Name', value: 'Value' }
+      expect(render template).to.equal '<br data-name="Name" data-value="Value" />'


### PR DESCRIPTION
Here's a small change to allow you to provide data attributes as an object:

``` coffee
a '.link', href: '/path', data: { val1: 'Value 1', val2: 'Value 2' }, 'A link with data attributes'
```

renders

``` html
<a class="link" href="/path" data-val1="Value 1" data-val2="Value 2">A link with data attributes</a>
```
