### PR TITLE
Implemented coffeescript tag

### DIFF
--- a/lib/teacup.js
+++ b/lib/teacup.js
@@ -272,8 +272,8 @@
       return this.raw("<" + tag + (this.renderAttrs(attrs)) + " />");
     };
 
-    Teacup.prototype.coffeescript = function() {
-      throw new Error('Teacup: coffeescript tag not implemented');
+    Teacup.prototype.coffeescript = function(fn) {
+      return this.raw("<script type=\"text/javascript\">(function() {\n  var __slice = [].slice,\n      __hasProp = {}.hasOwnProperty,\n      __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };\n  (" + (fn.toString()) + ")();\n})();</script>");
     };
 
     Teacup.prototype.comment = function(text) {

--- a/src/teacup.coffee
+++ b/src/teacup.coffee
@@ -184,8 +184,13 @@ class Teacup
       throw new Error "Teacup: <#{tag}/> must not have content.  Attempted to nest #{content}"
     @raw "<#{tag}#{@renderAttrs attrs} />"
 
-  coffeescript: ->
-    throw new Error 'Teacup: coffeescript tag not implemented'
+  coffeescript: (fn) ->
+    @raw """<script type="text/javascript">(function() {
+      var __slice = [].slice,
+          __hasProp = {}.hasOwnProperty,
+          __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+      (#{fn.toString()})();
+    })();</script>"""
 
   comment: (text) ->
     @raw "<!--#{@escape text}-->"

--- a/test/coffeescript.coffee
+++ b/test/coffeescript.coffee
@@ -1,15 +1,21 @@
 expect = require 'expect.js'
 {renderable, coffeescript} = require '..'
-          "pretest" : "coffee -cl -o lib src"
 
 describe 'coffeescript', ->
-  it 'is not implemented', ->
+  it 'renders script tag and javascript with coffee preamble scoped only to that javascript', ->
     template = renderable -> coffeescript -> alert 'hi'
-    expect(-> template()).to.throwException /coffeescript tag not implemented/
+    expected =  """<script type="text/javascript">(function() {
+      var __slice = [].slice,
+          __hasProp = {}.hasOwnProperty,
+          __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+          (function () {
+            return alert(\'hi\');
+          })();
+    })();</script>"""
+    # Equal ignoring insignificant whitespace
+    expect(template().replace(/[\n {2}]/g, '')).to.equal expected.replace(/[\n {2}]/g, '')
 
-  # it 'function should render', ->
-  #   t = -> coffeescript -> alert 'hi'
-  #   assert.equal cc.render(t), "<script>var __slice = Array.prototype.slice;var __hasProp = Object.prototype.hasOwnProperty;var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };var __extends = function(child, parent) {  for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; }  function ctor() { this.constructor = child; }  ctor.prototype = parent.prototype; child.prototype = new ctor; child.__super__ = parent.prototype;  return child; };var __indexOf = Array.prototype.indexOf || function(item) {  for (var i = 0, l = this.length; i < l; i++) {    if (this[i] === item) return i;  } return -1; };(function () {            return alert('hi');          }).call(this);</script>"
+
   # it 'string should render', ->
   #   t = -> coffeescript "alert 'hi'"
   #   assert.equal cc.render(t), "<script type=\"text/coffeescript\">alert 'hi'</script>"


### PR DESCRIPTION
Check it out. I was looking at converting the jujube layout to teacup and realized one thing we are using the the coffeescript tag. Here's an implementation that I think is a little bit better than the CoffeeCup original because it defines the coffeescript preamble (__slice,__extend) scoped only to the function you are calling. 

I didn't implement the other cases that are stil commented out in the coffeescript test.
