### PR TITLE
Prepend selector classes to attribute class

### DIFF
--- a/lib/teacup.js
+++ b/lib/teacup.js
@@ -217,6 +217,9 @@
           attrs.id = id;
         }
         if (classes != null ? classes.length : void 0) {
+          if (attrs["class"]) {
+            classes.push(attrs["class"]);
+          }
           attrs["class"] = classes.join(' ');
         }
       }

--- a/src/teacup.coffee
+++ b/src/teacup.coffee
@@ -151,7 +151,10 @@ class Teacup
     if selector?
       {id, classes} = selector
       attrs.id = id if id?
-      attrs.class = classes.join(' ') if classes?.length
+      if classes?.length
+        if attrs.class
+          classes.push attrs.class
+        attrs.class = classes.join(' ')
 
     return {attrs, contents}
 

--- a/test/css_selectors.coffee
+++ b/test/css_selectors.coffee
@@ -12,10 +12,16 @@ describe 'CSS Selectors', ->
       template = -> div '.myclass', 'foo'
       expect(render template).to.equal '<div class="myclass">foo</div>'
 
+    describe 'and a class attribute', ->
+      it 'prepends the selector class', ->
+        template = -> div '.myclass', 'class': 'myattrclass', 'foo'
+        expect(render template).to.equal '<div class="myclass myattrclass">foo</div>'
+
   describe 'multi-class selector', ->
     it 'adds all the classes', ->
       template = -> div '.myclass.myclass2.myclass3', 'foo'
       expect(render template).to.equal '<div class="myclass myclass2 myclass3">foo</div>'
+
 
   describe 'wihout contents', ->
     it 'still adds attributes', ->


### PR DESCRIPTION
With this change, setting an element class with both a CSS selector and an attribute combines the two, instead of clobbering the attribute class. For example:

``` coffee
div '.foo', 'class': 'bar'
```

yields

``` html
<div class="foo bar"></div>
```

instead of 

``` html
<div class="foo"></div>
```

This is useful when creating tag-like helpers that add default classes:

``` coffee
{button, normalizeArgs} = require 'teacup'

submit = ->
  {attrs, contents} = normalizeArgs arguments
  attrs.type = 'submit'
  button '.btn', attrs, contents

submit '.place-order', 'Order'
```

yields

``` html
<button class="btn place-order" type="submit">Order</button>
```
