### PR TITLE
allow for simple text functions like coffeecup did

### DIFF
--- a/lib/teacup.js
+++ b/lib/teacup.js
@@ -286,7 +286,8 @@
       if (this.htmlOut == null) {
         throw new Error("Teacup: can't call a tag function outside a rendering context");
       }
-      return this.htmlOut += (s != null) && this.escape(s.toString()) || '';
+      this.htmlOut += (s != null) && this.escape(s.toString()) || '';
+      return null;
     };
 
     Teacup.prototype.raw = function(s) {

--- a/src/teacup.coffee
+++ b/src/teacup.coffee
@@ -201,6 +201,7 @@ class Teacup
     unless @htmlOut?
       throw new Error("Teacup: can't call a tag function outside a rendering context")
     @htmlOut += s? and @escape(s.toString()) or ''
+    null
 
   raw: (s) ->
     return unless s?

--- a/test/text.coffee
+++ b/test/text.coffee
@@ -16,3 +16,5 @@ describe 'text', ->
     expect(render template).to.equal '<h1 class="title">hello world</h1>'
     template = -> h1 class: 'title', -> 'hello world'
     expect(render template).to.equal '<h1 class="title">hello world</h1>'
+    template = -> h1 '.title', -> text 'hello world'
+    expect(render template).to.equal '<h1 class="title">hello world</h1>'


### PR DESCRIPTION
I've wanted to upgrade from coffeecup to teacup for a while now.  Everything looks smooth except this one case where I think the way coffeecup handled it made a lot of sense.

This change would allow for writing templates like this...

```
h1 '.title', ->
  'My Title'
```

vs

```
h1 '.title', 'My Title'
```

It's extra typing, but I think it's a huge readability win.  It makes it really obvious that 'My Title' is nested within the element.  Personally, it feels weird putting content inline with the attributes.  I also still prefer `h1 class: 'title'` for clarity, but I imagine myself getting comfortable with h1 '.title' pretty quickly, because that's a big typing saver.

Let me know what you think.  All tests pass.
