### PR TITLE
Bulletproof express adapter

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -6,16 +6,18 @@
 
   module.exports = {
     renderFile: function(path, options, callback) {
-      var err;
-      try {
-        if ((options.app != null) && !options.app.enabled('view cache')) {
-          delete require.cache[require.resolve(path)];
+      return setImmediate(function() {
+        var err;
+        try {
+          if ((options.app != null) && !options.app.enabled('view cache')) {
+            delete require.cache[require.resolve(path)];
+          }
+          return callback(null, require(path)(options));
+        } catch (_error) {
+          err = _error;
+          return callback(err);
         }
-        return callback(null, require(path)(options));
-      } catch (_error) {
-        err = _error;
-        return callback(err);
-      }
+      });
     }
   };
 

--- a/src/express.coffee
+++ b/src/express.coffee
@@ -2,10 +2,11 @@ CoffeeScript = require 'coffee-script/register' # We need require support for .c
 
 module.exports =
   renderFile: (path, options, callback) ->
-    try
-      # If express app does not have view cache enabled, clear the require cache
-      if options.app? and not options.app.enabled('view cache')
-        delete require.cache[require.resolve path]
-      callback null, require(path)(options)
-    catch err
-      callback err
+    setImmediate ->
+      try
+        # If express app does not have view cache enabled, clear the require cache
+        if options.app? and not options.app.enabled('view cache')
+          delete require.cache[require.resolve path]
+        callback null, require(path)(options)
+      catch err
+        callback err

--- a/test/express.coffee
+++ b/test/express.coffee
@@ -15,7 +15,7 @@ describe 'express', ->
         expect(rendered).to.equal '<p>Name is Foo</p>'
         done()
 
-    it "returns error if not found", (done) ->
+    it 'calls back with an error if the template is not found', (done) ->
       renderFile './not_found.coffee', params, (err, rendered) ->
         expect(err).not.to.be(undefined)
         done()

--- a/test/express.coffee
+++ b/test/express.coffee
@@ -1,4 +1,5 @@
 expect = require 'expect.js'
+teacup = require '..'
 {renderFile} = require '../lib/express'
 
 describe 'express', ->
@@ -19,6 +20,14 @@ describe 'express', ->
       renderFile './not_found.coffee', params, (err, rendered) ->
         expect(err).not.to.be(undefined)
         done()
+
+    it 'renders in an independent event loop, to escape fibers if used', (done) ->
+      global.teacupTestRendered = false
+      renderFile path, params, (err, rendered) ->
+        return done(err) if err?
+        expect(global.teacupTestRendered).to.equal true
+        done()
+      expect(global.teacupTestRendered).to.equal false
 
     describe 'with view cache enabled', ->
       beforeEach ->

--- a/test/express_template.coffee
+++ b/test/express_template.coffee
@@ -1,4 +1,6 @@
 {renderable, p} = require '..'
 
 module.exports = renderable ({name}) ->
+  # Flag used to assert timing of rendering
+  global.teacupTestRendered = true
   p "Name is #{name}"

--- a/test/plugins.coffee
+++ b/test/plugins.coffee
@@ -3,5 +3,4 @@ teacup = require '..'
 
 describe 'plugins', ->
   it 'are applied via use', ->
-    console.log teacup
     expect(teacup.use).to.be.a 'function'

--- a/test/render.coffee
+++ b/test/render.coffee
@@ -15,10 +15,10 @@ describe 'render', ->
           raw "This text could use #{cede -> strong -> a href: '/', 'a link'}."
       expect(render template).to.equal '<p>This text could use <strong><a href="/">a link</a></strong>.</p>'
 
-    it 'doesn\'t modify the attributes object', ->
-      d = { id: 'foobar', class: 'myclass', href: 'http://example.com', }
-      template = ->
-        p ->
-          a d, "link 1"
-          a d, "link 2"
-      expect(render template).to.equal '<p><a id="foobar" class="myclass" href="http://example.com">link 1</a><a id="foobar" class="myclass" href="http://example.com">link 2</a></p>'
+  it 'doesn\'t modify the attributes object', ->
+    d = { id: 'foobar', class: 'myclass', href: 'http://example.com', }
+    template = ->
+      p ->
+        a d, "link 1"
+        a d, "link 2"
+    expect(render template).to.equal '<p><a id="foobar" class="myclass" href="http://example.com">link 1</a><a id="foobar" class="myclass" href="http://example.com">link 2</a></p>'


### PR DESCRIPTION
Fixes #50.

Of the 3 suggestions, I implemented only one:

> Render templates in their own event loop (via setImmediate) so that fibers aren't available to yield.

With that in place, I couldn't write failing specs for the other two, suggesting the assertions are overkill.