### PR TITLE
Benchmark current performance against the competition

### DIFF
--- a/benchmark/data.coffee
+++ b/benchmark/data.coffee
@@ -1,0 +1,8 @@
+module.exports =
+  title: 'test'
+  inspired: no
+  users: [
+    {email: 'house@gmail.com', name: 'house'}
+    {email: 'cuddy@gmail.com', name: 'cuddy'}
+    {email: 'wilson@gmail.com', name: 'wilson'}
+  ]

--- a/benchmark/dot/dot_template.dot
+++ b/benchmark/dot/dot_template.dot
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>{{! it.title }}</title>
+  <style>
+    body {font-family: "sans-serif"}
+    section, header {display: block}
+  </style>
+</head>
+<body>
+  <section>
+    <header>
+      <h1>{{! it.title }}</h1>
+    </header>
+  </section>
+  {{? it.inspired }}
+    <p>Create a witty example</p>
+  {{??}}
+    <p>Go meta</p>
+  {{?}}
+  <ul>
+    {{~it.users :user:index}}
+      <li>{{! user.name }}</li>
+      <li>
+        <a href="mailto:{{! user.email }}">{{! user.email }}</a>
+      </li>
+    {{~}}
+  </ul>
+</body>
+</html>

--- a/benchmark/index.coffee
+++ b/benchmark/index.coffee
@@ -1,0 +1,42 @@
+fs = require 'fs'
+Benchmark = require 'benchmark'
+
+global.data = require './data'
+loadTemplate = (filename) ->
+  fs.readFileSync "#{__dirname}/#{filename}", encoding: 'utf8'
+
+suite = new Benchmark.Suite()
+.on 'cycle', (event) ->
+  console.log event.target.toString()
+.on 'error', (event) ->
+  error = event.target.error
+  console.error error.stack
+
+
+# Teacup
+unadorned = require './teacup_unadorned'
+suite.add 'unadorned', ->
+  unadorned data
+
+# Jade
+jade = require 'jade'
+jadeUnadorned = jade.compile loadTemplate 'template.jade'
+suite.add 'jade', -> jadeUnadorned data
+
+# Underscore
+_ = require 'underscore'
+underscored = _.template loadTemplate 'underscore.html'
+suite.add 'underscore', ->
+  underscored data
+
+underscoreNoWith = _.template loadTemplate('underscore_no_with.html'), variable: 'data'
+suite.add 'underscore (no with)', ->
+  underscoreNoWith data
+
+# Dot
+dots = require('dot').process path: "#{__dirname}/dot"
+suite.add 'dot', ->
+  dots.dot_template data
+
+suite.run(async: true)
+

--- a/benchmark/teacup_unadorned.coffee
+++ b/benchmark/teacup_unadorned.coffee
@@ -1,0 +1,28 @@
+# Lifted from coffeecup:
+# https://github.com/gradus/coffeecup/blob/81bda8d28e626cf5b1e5105ec9bf01eef7ed6f7e/optimized_bench.coffee
+
+{renderable, doctype, html, head, meta, link, style, title, script, body,
+header, section, nav, footer, h1, h2, ul, li, a, p} = require '..'
+
+module.exports = renderable ({title: titleText, inspired, users}) ->
+  doctype 5
+  html lang: 'en', ->
+    head ->
+      meta charset: 'utf-8'
+      title titleText
+      style '''
+        body {font-family: "sans-serif"}
+        section, header {display: block}
+      '''
+    body ->
+      section ->
+        header ->
+          h1 titleText
+        if inspired
+          p 'Create a witty example'
+        else
+          p 'Go meta'
+        ul ->
+          for user in users
+            li user.name
+            li -> a href: "mailto:#{user.email}", -> user.email

--- a/benchmark/template.jade
+++ b/benchmark/template.jade
@@ -1,0 +1,21 @@
+doctype html
+html(lang="en")
+  head
+    meta(charset="utf-8")
+    title= title
+    style
+      | body {font-family: "sans-serif"}
+      | section, header {display: block}
+  body
+    section
+      header
+        h1= title
+      - if (inspired)
+        p Create a witty example
+      - else
+        p Go meta
+      ul
+        - each user in users
+          li= user.name
+          li
+            a(href="mailto:"+user.email)= user.email

--- a/benchmark/underscore.html
+++ b/benchmark/underscore.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title><%- title %></title>
+  <style>
+    body {font-family: "sans-serif"}
+    section, header {display: block}
+  </style>
+</head>
+<body>
+  <section>
+    <header>
+      <h1><%- title %></h1>
+    </header>
+  </section>
+  <% if (inspired) { %>
+    <p>Create a witty example</p>
+  <% } else { %>
+    <p>Go meta</p>
+  <% } %>
+  <ul>
+    <% _.each(users, function(user) { %>
+      <li><%- user.name %></li>
+      <li>
+        <a href="mailto:<%- user.email %>"><%- user.email %></a>
+      </li>
+    <% }) %>
+  </ul>
+</body>
+</html>

--- a/benchmark/underscore_no_with.html
+++ b/benchmark/underscore_no_with.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title><%- data.title %></title>
+  <style>
+    body {font-family: "sans-serif"}
+    section, header {display: block}
+  </style>
+</head>
+<body>
+  <section>
+    <header>
+      <h1><%- data.title %></h1>
+    </header>
+  </section>
+  <% if (data.inspired) { %>
+    <p>Create a witty example</p>
+  <% } else { %>
+    <p>Go meta</p>
+  <% } %>
+  <ul>
+    <% _.each(data.users, function(user) { %>
+      <li><%- user.name %></li>
+      <li>
+        <a href="mailto:<%- user.email %>"><%- user.email %></a>
+      </li>
+    <% }) %>
+  </ul>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -25,12 +25,16 @@
     "coffee-script": ">=1.8.0",
     "connect-assets": "*",
     "mocha": "*",
-    "expect.js": "*"
+    "expect.js": "*",
+    "benchmark": "~1.0.0",
+    "jade": "~1.9.2",
+    "dot": "~1.0.3"
   },
   "scripts": {
     "pretest": "npm run compile",
     "prepublish": "npm run compile",
     "test": "mocha",
-    "compile": "coffee --compile --output lib/ src/"
+    "compile": "coffee --compile --output lib/ src/",
+    "benchmark": "coffee benchmark/index.coffee"
   }
 }


### PR DESCRIPTION
Prompted by #48.  Curious how performance stacks up today?  Try `npm run benchmark`.  Here's what I see:

```
teacup x 19,922 ops/sec ±1.44% (93 runs sampled)  
jade x 30,992 ops/sec ±0.65% (91 runs sampled)
underscore x 158,144 ops/sec ±0.86% (92 runs sampled)
underscore (no with) x 903,490 ops/sec ±0.66% (93 runs sampled)
dot x 460,082 ops/sec ±0.55% (92 runs sampled)
```

Jade is 1.5x faster.  Underscore, used optimally, is 45x faster.  Dot is 23x faster, and no longer the fastest on the block.

CoffeeCup saw a 10x speedup with a [complex source transformation](https://github.com/gradus/coffeecup/blob/master/src/compiler.coffee), suggesting we could get within 5x of underscore.

Based on these rough numbers, our pages would have to be ~1000x more complicated than the test page before we see template rendering on the order of 50ms.
