### PR TITLE
escapes </script sequences within script tags

### DIFF
--- a/lib/teacup.js
+++ b/lib/teacup.js
@@ -262,7 +262,9 @@
       tagName = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
       ref = this.normalizeArgs(args), attrs = ref.attrs, contents = ref.contents;
       this.raw("<" + tagName + (this.renderAttrs(attrs)) + ">");
-      this.renderContents(contents);
+      if (contents != null) {
+        this.raw(this.scriptEscape(contents));
+      }
       return this.raw("</" + tagName + ">");
     };
 
@@ -277,7 +279,7 @@
     };
 
     Teacup.prototype.coffeescript = function(fn) {
-      return this.raw("<script type=\"text/javascript\">(function() {\n  var __slice = [].slice,\n      __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },\n      __hasProp = {}.hasOwnProperty,\n      __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };\n  (" + (this.escape(fn.toString())) + ")();\n})();</script>");
+      return this.raw("<script type=\"text/javascript\">(function() {\n  var __slice = [].slice,\n      __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },\n      __hasProp = {}.hasOwnProperty,\n      __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };\n  (" + (this.scriptEscape(fn.toString())) + ")();\n})();</script>");
     };
 
     Teacup.prototype.comment = function(text) {
@@ -316,6 +318,14 @@
     Teacup.prototype.escape = function(text) {
       return text.toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     };
+
+    Teacup.prototype.scriptEscape = (function() {
+      var matcher;
+      matcher = /<\/script([\s>\/])/g;
+      return function(str) {
+        return str.replace(matcher, '<\\/script$1');
+      };
+    })();
 
     Teacup.prototype.quote = function(value) {
       return "\"" + value + "\"";

--- a/src/teacup.coffee
+++ b/src/teacup.coffee
@@ -1,3 +1,4 @@
+
 doctypes =
   'default': '<!DOCTYPE html>'
   '5': '<!DOCTYPE html>'
@@ -179,9 +180,8 @@ class Teacup
   scriptTag: (tagName, args...) ->
     {attrs, contents} = @normalizeArgs args
     @raw "<#{tagName}#{@renderAttrs attrs}>"
-    @renderContents contents
+    @raw @scriptEscape(contents) if contents?
     @raw "</#{tagName}>"
-
 
   selfClosingTag: (tag, args...) ->
     {attrs, contents} = @normalizeArgs args
@@ -195,7 +195,7 @@ class Teacup
           __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; },
           __hasProp = {}.hasOwnProperty,
           __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
-      (#{@escape fn.toString()})();
+      (#{@scriptEscape fn.toString()})();
     })();</script>"""
 
   comment: (text) ->
@@ -232,6 +232,11 @@ class Teacup
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
 
+  scriptEscape: do ->
+    matcher = /<\/script([\s>\/])/g
+    (str) ->
+      str.replace matcher, '<\\/script$1'
+  
   quote: (value) ->
     "\"#{value}\""
 

--- a/test/coffeescript.coffee
+++ b/test/coffeescript.coffee
@@ -19,10 +19,10 @@ describe 'coffeescript', ->
 
   it 'escapes the function contents for script tag', ->
     template = renderable -> coffeescript ->
-      user = name: '</script><script>alert("alert");</script>'
+      user = name: '</script ><script>alert("alert");</script>'
       alert "Hello #{user.name}!"
 
-    expect(template()).to.contain "'&lt;/script&gt;&lt;script&gt;alert(&quot;alert&quot;);&lt;/script&gt;'"
+    expect(template()).to.contain "'<\\/script ><script>alert(\"alert\");<\\/script>'"
 
   # it 'string should render', ->
   #   t = -> coffeescript "alert 'hi'"

--- a/test/escaping.coffee
+++ b/test/escaping.coffee
@@ -29,8 +29,8 @@ describe 'raw filter', ->
 
 describe 'script tag', ->
   it 'escapes /', ->
-    user = name: '</script><script>alert("alert");</script>'
+    user = name: '</script ><script>alert("alert");</script>'
     template = ->
       script "window.user = #{JSON.stringify user}"
 
-    expect(render template).to.equal '<script>window.user = {&quot;name&quot;:&quot;&lt;/script&gt;&lt;script&gt;alert(\\&quot;alert\\&quot;);&lt;/script&gt;&quot;}</script>'
+    expect(render template).to.equal '<script>window.user = {"name":"<\\/script ><script>alert(\\"alert\\");<\\/script>"}</script>'


### PR DESCRIPTION
@adborden @hurrymaplelad interested to get your thoughts on this.
#54 might have been ok for XML/XHTML doctypes, but it definitely breaks HTML doctypes.  `script` tags are CDATA by default, so the entities escaping is wrong.

This will remove the HTML escaping from script tags and solve the [closing script tag issue](http://www.jibbering.com/faq/faq_notes/script_tags.html#hsETO) by escaping `</script` sequences with `<\/script`.

There's another alternative which is to revert #54 and not replace it with anything -- perhaps escaping script tag content should be left up to the developer, as the exact correct behavior seems to depend on context?
